### PR TITLE
Calculate CDPP to optimize final aperture

### DIFF
--- a/src/autoeapcore.py
+++ b/src/autoeapcore.py
@@ -1152,7 +1152,8 @@ def createlightcurve(targettpf, apply_K2SC=False, remove_spline=False, save_lc=F
 
 
                 # --- Removing outliers before saving light curve (or removing spline) ---
-                lclist[variableindex] = lclist[variableindex].remove_nans().remove_outliers()
+                lclist[variableindex], badpts   = lclist[variableindex].remove_outliers(return_mask=True)
+                lclist[variableindex].corr_flux = lclist[variableindex].corr_flux[~badpts]
 
                 if save_plots or show_plots:
                     fig = plt.figure(figsize=(20,4))

--- a/src/autoeapcore.py
+++ b/src/autoeapcore.py
@@ -768,7 +768,7 @@ def optimize_aperture_wrt_CDPP(lclist,variableindex,gapfilledaperturelist,initia
             if show_plots: plt.show()
             plt.close(fig)
 
-        newlc = tpf.to_lightcurve(aperture_mask=newmask).remove_nans().remove_outliers()
+        newlc = tpf.to_lightcurve(aperture_mask=newmask)
         lccdpp = newlc.estimate_cdpp()
         if debug: print('New CDPP =', lccdpp )
 
@@ -822,7 +822,7 @@ def optimize_aperture_wrt_CDPP(lclist,variableindex,gapfilledaperturelist,initia
             newmask[ i0,j0 ] = True
             newmask[gapfilledaperturelist[variableindex]] = True
 
-            newlc = tpf.to_lightcurve(aperture_mask=newmask).remove_nans().remove_outliers()
+            newlc = tpf.to_lightcurve(aperture_mask=newmask)
             lccdpp = newlc.estimate_cdpp()
 
             if lccdpp < cdpp_list[bestcdpp]:
@@ -839,7 +839,7 @@ def optimize_aperture_wrt_CDPP(lclist,variableindex,gapfilledaperturelist,initia
         newmask[initialmask] = False
         newmask[gapfilledaperturelist[variableindex]] = True
 
-        newfinallc = tpf.to_lightcurve(aperture_mask=newmask).remove_nans().remove_outliers()
+        newfinallc = tpf.to_lightcurve(aperture_mask=newmask)
 
         if save_plots or show_plots:
             fig,axs = plt.subplots(2,1,figsize=(20,8))
@@ -1064,7 +1064,7 @@ def createlightcurve(targettpf, apply_K2SC=False, remove_spline=False, save_lc=F
         fig,axs = plt.subplots(np.max(aps),1,figsize=(12,np.max(aps)*2),squeeze=False)
         lclist=[]
         for x in range(np.max(aps)):
-            lc=tpf.to_lightcurve(aperture_mask=gapfilledaperturelist[x]).remove_nans().remove_outliers()
+            lc=tpf.to_lightcurve(aperture_mask=gapfilledaperturelist[x])
             lclist.append(lc)
 
             try: axs[x,0].plot(lc.time.value,lc.flux.value)
@@ -1121,9 +1121,10 @@ def createlightcurve(targettpf, apply_K2SC=False, remove_spline=False, save_lc=F
 
                 lclist[variableindex].primary_header = tpf.hdu[0].header
                 lclist[variableindex].data_header = tpf.hdu[1].header
-                lc.pos_corr1 = tpf.hdu[1].data['POS_CORR1'][tpf.quality_mask]
-                lc.pos_corr2 = tpf.hdu[1].data['POS_CORR2'][tpf.quality_mask]
+                lclist[variableindex].pos_corr1 = tpf.hdu[1].data['POS_CORR1'][tpf.quality_mask]
+                lclist[variableindex].pos_corr2 = tpf.hdu[1].data['POS_CORR2'][tpf.quality_mask]
                 lclist[variableindex].__class__ = k2sc_lc
+
                 try:
                     period, fap = psearch(lclist[variableindex].time.value,lclist[variableindex].flux.value,min_p=0,max_p=lclist[variableindex].time.value.ptp()/2)
                 except AttributeError:
@@ -1169,6 +1170,8 @@ def createlightcurve(targettpf, apply_K2SC=False, remove_spline=False, save_lc=F
                     ascii.write(table,targettpf+'_c'+str(campaignnum)+'_autoEAP_k2sc.lc',overwrite=True)
 
                 print('Done')
+
+
                 try:
                     return lclist[variableindex].time.value, lclist[variableindex].corr_flux, lclist[variableindex].flux_err.value
                 except AttributeError:

--- a/src/autoeapcore.py
+++ b/src/autoeapcore.py
@@ -1150,6 +1150,10 @@ def createlightcurve(targettpf, apply_K2SC=False, remove_spline=False, save_lc=F
 
                 lclist[variableindex].k2sc(campaign=campaignnum, kernel='quasiperiodic',kernel_period=period)
 
+
+                # --- Removing outliers before saving light curve (or removing spline) ---
+                lclist[variableindex] = lclist[variableindex].remove_nans().remove_outliers()
+
                 if save_plots or show_plots:
                     fig = plt.figure(figsize=(20,4))
                     try: plt.plot(lclist[variableindex].time.value,lclist[variableindex].corr_flux)
@@ -1203,6 +1207,9 @@ def createlightcurve(targettpf, apply_K2SC=False, remove_spline=False, save_lc=F
 
             break
 
+    # --- Removing outliers before saving light curve (or removing spline) ---
+    lclist[variableindex] = lclist[variableindex].remove_nans().remove_outliers()
+
     if remove_spline:
         # --- Remove spline from raw light curve ---
         print('Removing spline')
@@ -1213,13 +1220,14 @@ def createlightcurve(targettpf, apply_K2SC=False, remove_spline=False, save_lc=F
 
         if save_lc:
             # --- Save spline corrected raw light curve ---
-
             print('Saving lc as '+targettpf+'_c'+str(campaignnum)+'_autoEAP_spline.lc')
+
             table = lclist[variableindex].to_table()['time','flux','flux_err']
             table['splined_flux'] = splinedLC
             ascii.write(table,targettpf+'_c'+str(campaignnum)+'_autoEAP_spline.lc',overwrite=True)
 
         print('Done')
+
         try:
             return lclist[variableindex].time.value, splinedLC, lclist[variableindex].flux_err.value
         except AttributeError:
@@ -1227,12 +1235,13 @@ def createlightcurve(targettpf, apply_K2SC=False, remove_spline=False, save_lc=F
 
     if save_lc:
         # --- Save raw light curve ---
-
         print('Saving lc as '+targettpf+'_c'+str(campaignnum)+'_autoEAP.lc')
+
         table = lclist[variableindex].to_table()['time','flux','flux_err']
         ascii.write(table,targettpf+'_c'+str(campaignnum)+'_autoEAP.lc',overwrite=True)
 
     print('Done')
+
     try:
         return lclist[variableindex].time.value, lclist[variableindex].flux.value, lclist[variableindex].flux_err.value
     except AttributeError:

--- a/src/autoeapcore.py
+++ b/src/autoeapcore.py
@@ -1121,6 +1121,8 @@ def createlightcurve(targettpf, apply_K2SC=False, remove_spline=False, save_lc=F
 
                 lclist[variableindex].primary_header = tpf.hdu[0].header
                 lclist[variableindex].data_header = tpf.hdu[1].header
+                lc.pos_corr1 = tpf.hdu[1].data['POS_CORR1'][tpf.quality_mask]
+                lc.pos_corr2 = tpf.hdu[1].data['POS_CORR2'][tpf.quality_mask]
                 lclist[variableindex].__class__ = k2sc_lc
                 try:
                     period, fap = psearch(lclist[variableindex].time.value,lclist[variableindex].flux.value,min_p=0,max_p=lclist[variableindex].time.value.ptp()/2)

--- a/src/autoeapcore.py
+++ b/src/autoeapcore.py
@@ -865,7 +865,7 @@ def optimize_aperture_wrt_CDPP(lclist,variableindex,gapfilledaperturelist,initia
                 plt.plot(filtered[x][0],filtered[x][1],linewidth=4,ls='--',c='C1')
 
             plt.tight_layout()
-            if save_plots: plt.savefig(targettpf+'_plots/'+targettpf+'tpf_aperture_after_CDPP_correction.png')
+            if save_plots: plt.savefig(targettpf+'_plots/'+targettpf+'_tpf_aperture_after_CDPP_correction.png')
             if show_plots: plt.show()
             plt.close(fig)
     else:

--- a/src/k2sc_stable.py
+++ b/src/k2sc_stable.py
@@ -292,7 +292,7 @@ class k2sc_lc(lightkurve.KeplerLightCurve):
     def get_k2data(self):
         try:
             try: x, y = self.pos_corr1.value, self.pos_corr2.value
-            except AttributeError: self.pos_corr1, self.pos_corr2
+            except AttributeError: x, y = self.pos_corr1, self.pos_corr2
         except:
             try: x, y = self.centroid_col.value, self.centroid_row.value
             except AttributeError: x, y = self.centroid_col, self.centroid_row

--- a/src/k2sc_stable.py
+++ b/src/k2sc_stable.py
@@ -245,7 +245,7 @@ def detrend(dataset,campaign=5,splits=None,quiet=False,save_dir='.',seed=0,flux_
         print('Detrending time %6.3f'% (time()-tstart))
 
 
-        print(result)
+        #print(result)
         return result
 
 M_QUALITY    = 2**0


### PR DESCRIPTION
After we find the final aperture using sigma threshold and Gaia separation, the adjacent pixels are added and CDPP is calculated. If we can find a lower CDPP, we add those adjacent pixels, thus extend the aperture more.

Additionally, `POS_CORR` is passed to K2SC, making sure that the GP fit uses the photocenter movement.