### PR TITLE
Compatibility with Lightkurve2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ plt.show()
 
 The details of the workflow is described in [docs](https://github.com/zabop/autoeap/tree/master/docs).
 
-You can find Google Colab friendly tutorial [in the examples](https://github.com/zabop/autoeap/tree/master/examples).
+You can find Google Colab friendly tutorials [in the examples](https://github.com/zabop/autoeap/tree/master/examples).
 
 ### Apply K2 Systematics Correction (K2SC)
 If you want to apply K2SC correction for your freshly made raw-photometry, first you should install [K2SC](https://github.com/OxES/k2sc). AutoEAP is based on that package, so if you find K2SC useful, please cite [Aigrain et al.,2016,MNRAS,459,2408](https://ui.adsabs.harvard.edu/abs/2016MNRAS.459.2408A/abstract).
@@ -92,11 +92,16 @@ time, flux, flux_err = autoeap.createlightcurve(yourtpf,apply_K2SC=True,remove_s
  - `remove_spline` If `True`, after the raw photomery, a low-order spline will be fitted and removed from the extracted light curve. If ``apply_K2SC`` is also `True`, then this step will be done after the K2SC.
  - `save_lc` If `True`, the intermediate and the final light curves will be save as a file.
  - `campaign` If local TPF file is not found, it will be downloaded from MAST, but ``campaign`` number should be defined as well, if the target has been observed in more than one campaign. Otherwise that campaign will be used in which the target were first observed.
- - `TH` Threshold to segment each target in each TPF candence. Only used if targets cannot be separated normally. Default is `8`.
  - `show_plots` If `True`, all the plots will be displayed.
  - `save_plots` If `True`, all the plots will be saved to a subdirectory.
  - `window_length` The length of filter window for spline correction given in days. Applies only if ``remove_spline`` is `True`. Default is `20` days.
- 
+ - `sigma_lower` The number of standard deviations to use as the lower bound for sigma clipping limit before spline correction. Applies only if ``remove_spline`` is `True`. Default is `3`.
+ - `sigma_upper` The number of standard deviations to use as the upper bound for sigma clipping limit before spline correction. Applies only if ``remove_spline`` is `True`. Default is `3`.
+  - `TH` Threshold to segment each target in each TPF candence. Only used if targets cannot be separated normally. Default is `8`. Do not change this value unless you are aware of what you are doing!
+  - `ROI_lower` The aperture frequency grid range of interest threshold given in absolute number of selections above which pixels are considered to define the apertures.  Do not change this value unless you are aware of what you are doing! Default is `100`.
+  - `ROI_upper` The aperture frequency grid range of interest threshold given in relative number of selections w.r.t. the number of all cadences below which pixels are considered to define the apertures. Do not change this value unless you are aware of what you are doing! Default is `0.85`.
+- `**kwargs` Dictionary of arguments to be passed to ``k2sc.detrend``.
+
 ## Data Access
 
 We provide photometry for targets for the following Guest Observation Programs:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.11
 scipy>=0.19.0,!=1.4.0,!=1.4.1
 matplotlib>=1.5.3
-lightkurve<2.0
+lightkurve
 sklearn
 astropy>=4.1rc1
 wotan

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.11
 scipy>=0.19.0,!=1.4.0,!=1.4.1
 matplotlib>=1.5.3
-lightkurve
+lightkurve>=1.5
 sklearn
 astropy>=4.1rc1
 wotan

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ wotan
 tqdm>=4.25.0
 numba
 memoization
+oktopus

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ astropy>=4.1rc1
 wotan
 tqdm>=4.25.0
 numba
+memoization

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ tqdm>=4.25.0
 numba
 memoization
 oktopus
+astroquery

--- a/src/autoeapcore.py
+++ b/src/autoeapcore.py
@@ -1158,7 +1158,9 @@ def createlightcurve(targettpf, apply_K2SC=False, remove_spline=False, save_lc=F
                     # --- Remove spline from K2SC corrected light curve ---
                     print('Removing spline')
 
-                    splinedLC, trendLC = splinecalc( strip_quantity(lclist[variableindex].time), lclist[variableindex].corr_flux,window_length=window_length)
+                    splinedLC, trendLC = splinecalc( strip_quantity(lclist[variableindex].time),
+                                                        strip_quantity(lclist[variableindex].corr_flux),
+                                                        window_length=window_length)
 
                     if save_lc:
                         # --- Save K2SC + spline corrected light curve ---
@@ -1182,7 +1184,7 @@ def createlightcurve(targettpf, apply_K2SC=False, remove_spline=False, save_lc=F
 
                 print('Done')
 
-                return strip_quantity(lclist[variableindex].time), lclist[variableindex].corr_flux, strip_quantity(lclist[variableindex].flux_err)
+                return strip_quantity(lclist[variableindex].time), strip_quantity(lclist[variableindex].corr_flux), strip_quantity(lclist[variableindex].flux_err)
 
             break
 

--- a/src/autoeapcore.py
+++ b/src/autoeapcore.py
@@ -673,8 +673,8 @@ def which_one_is_a_variable(lclist,iterationnum,eachfile,show_plots=False,save_p
         axs[ii,0].legend()
 
         # Period must be shorten than half of data length
-        power     = power[    2/lc.time.ptp() < frequency]
-        frequency = frequency[2/lc.time.ptp() < frequency]
+        power     = power[    2/strip_quantity(lc.time).ptp() < frequency]
+        frequency = frequency[2/strip_quantity(lc.time).ptp() < frequency]
 
         winsorize = power<np.nanpercentile(power,95)
 

--- a/src/autoeapcore.py
+++ b/src/autoeapcore.py
@@ -8,9 +8,10 @@ import matplotlib.pyplot as plt
 import lightkurve
 import warnings
 from astropy.units.quantity import Quantity
+from astropy.time.core import Time
 
 def strip_quantity(data):
-    if isinstance(data, Quantity):
+    if isinstance(data, Quantity) or isinstance(data, Time):
         return data.value
     else:
         return data

--- a/src/autoeapcore.py
+++ b/src/autoeapcore.py
@@ -655,6 +655,9 @@ def which_one_is_a_variable(lclist,iterationnum,eachfile,show_plots=False,save_p
                                         minimum_frequency=2/lc.time.ptp(),
                                         nyquist_factor=1)
 
+        frequency = strip_quantity(frequency)
+        power     = strip_quantity(power)
+
         sixhourspeak = 4.06998484731612
         df = 1/lc.time.ptp()
         for jj in range(5):
@@ -668,9 +671,6 @@ def which_one_is_a_variable(lclist,iterationnum,eachfile,show_plots=False,save_p
         #plt.xlim([2/lclist[q].time.ptp(), nyquist/2])
         axs[ii,0].set_ylim(bottom=0)
         axs[ii,0].legend()
-
-        frequency = strip_quantity(frequency)
-        power     = strip_quantity(power)
 
         # Period must be shorten than half of data length
         power     = power[    2/lc.time.ptp() < frequency]

--- a/src/autoeapcore.py
+++ b/src/autoeapcore.py
@@ -301,6 +301,7 @@ def draw_a_single_aperture(tpf,cadence,segm,eachfile,show_plots=False,save_plots
     for x in range(len(filtered)):
         plt.plot(np.asarray(filtered[x][0])-0.5,np.asarray(filtered[x][1])-0.5,c='r',linewidth=12)
         plt.plot(np.asarray(filtered[x][0])-0.5,np.asarray(filtered[x][1])-0.5,c='w',linewidth=6)
+    plt.tight_layout()
     if save_plots: plt.savefig(eachfile+'_plots/'+eachfile+'_single_tpf_cadencenum_'+str(cadence)+'.png')
     if show_plots: plt.show()
     plt.close(fig)
@@ -414,6 +415,7 @@ def aperture_prep(inputfile,campaign=None,show_plots=False,save_plots=False):
         ax2.scatter(psfc2[np.where(core_samples_mask == False)], strip_quantity(tpf.time[np.where(core_samples_mask == False)]) ,s=5,c='r')
         ax2.set_xlabel('PSF CENTR2',fontsize=14)
         ax2.set_ylabel('BJD',fontsize=14)
+        plt.tight_layout()
         if save_plots: plt.savefig(inputfile+'_plots/'+inputfile+'_PSF_centroid.png')
         if show_plots: plt.show()
         plt.close(fig)
@@ -1049,6 +1051,7 @@ def createlightcurve(targettpf, apply_K2SC=False, remove_spline=False, save_lc=F
                 for x in range(len(filtered)):
                     plt.plot(filtered[x][0],filtered[x][1],c=color,linewidth=4)
 
+            plt.tight_layout()
             if save_plots: plt.savefig(targettpf+'_plots/'+targettpf+'_tpfplot_iternum_'+str(iterationnum)+'.png')
             if show_plots: plt.show()
             plt.close(fig)
@@ -1146,6 +1149,7 @@ def createlightcurve(targettpf, apply_K2SC=False, remove_spline=False, save_lc=F
                     plt.title('K2SC corrected lc for '+targettpf)
                     plt.xlabel('Time')
                     plt.ylabel('Flux')
+                    plt.tight_layout()
                     if save_plots: plt.savefig(targettpf+'_plots/'+targettpf+'_k2sc_lc_plot.png')
                     if show_plots: plt.show()
                     plt.close(fig)

--- a/src/autoeapcore.py
+++ b/src/autoeapcore.py
@@ -920,9 +920,10 @@ def splinecalc(time,flux,window_length=20,sigma_lower=3,sigma_upper=3):
     return splinedLC, trendLC
 
 
-def createlightcurve(targettpf, apply_K2SC=False, remove_spline=False, save_lc=False, campaign=None, TH=8,
+def createlightcurve(targettpf, apply_K2SC=False, remove_spline=False, save_lc=False, campaign=None,
                         show_plots=False, save_plots=False,
                         window_length=20, sigma_lower=3, sigma_upper=3,
+                        TH=8, ROI_lower=100, ROI_upper=0.85,
                         debug=False, **kwargs):
     """
     ``createlightcurve`` performs photomerty on K2 variable stars
@@ -950,23 +951,34 @@ def createlightcurve(targettpf, apply_K2SC=False, remove_spline=False, save_lc=F
         If `True` all the plots will be displayed.
     save_plots: bool, default: False
         If `True` all the plots will be saved to a subdirectory.
-    window_length: int of float, default: 20
+    window_length: int or float, default: 20
         The length of filter window for spline correction given in days. Applies
         only if ``remove_spline`` is `True`.
-    sigma_lower: int of float, default: 3
+    sigma_lower: int or float, default: 3
         The number of standard deviations to use as the lower bound for sigma
         clipping limit before spline correction. Applies only
         if ``remove_spline`` is `True`.
-    sigma_upper: int of float, default: 3
+    sigma_upper: int or float, default: 3
         The number of standard deviations to use as the upper bound for sigma
         clipping limit before spline correction. Applies only
         if ``remove_spline`` is `True`.
-    **kwargs: dict
-        Dictionary of arguments to be passed to k2sc.detrend.
-    TH : int of float, default: 8
+    TH : int or float, default: 8
         Threshold to segment each target in each TPF candence. Only used if
         targets cannot be separated normally. Do not change this value unless
         you are aware of what you are doing.
+    ROI_lower: int, default: 100
+        The aperture frequency grid range of interest threshold given in
+        absolute number of selections above which pixels are considered to
+        define the apertures.  Do not change this value unless you are
+        aware of what you are doing.
+    ROI_upper: float, default: 0.85
+        The aperture frequency grid range of interest threshold given in
+        relative number of selections w.r.t. the number of all cadences below
+        which pixels are considered to define the apertures. Do not change
+        this value unless you are aware of what you are doing.
+    **kwargs: dict
+        Dictionary of arguments to be passed to k2sc.detrend.
+
     Returns
     -------
     time : array-like
@@ -1016,7 +1028,7 @@ def createlightcurve(targettpf, apply_K2SC=False, remove_spline=False, save_lc=F
             numfeatureslist.append(num_features)
 
         # --- Separate stars and define one aperture for each star ---
-        ROI=[100, len(tpf.flux)*0.85]
+        ROI=[ROI_lower, len(tpf.flux)*ROI_upper]
         apertures, extensionprospects, apindex = defineaperture(numfeatureslist,countergrid_all, ROI, filterpassingpicsnum, TH,debug=debug)
 
         if save_plots or show_plots:

--- a/src/autoeapcore.py
+++ b/src/autoeapcore.py
@@ -920,7 +920,7 @@ def splinecalc(time,flux,window_length=20):
 
 def createlightcurve(targettpf, apply_K2SC=False, remove_spline=False, save_lc=False, campaign=None, TH=8,
                         show_plots=False, save_plots=False, window_length=20,
-                        debug=False):
+                        debug=False,**kwargs):
     """
     ``createlightcurve`` performs photomerty on K2 variable stars
 
@@ -953,6 +953,7 @@ def createlightcurve(targettpf, apply_K2SC=False, remove_spline=False, save_lc=F
     window_length: int of float, default: 20
         The length of filter window for spline correction given in days. Applies only
         if ``remove_spline`` is `True`.
+    **kwargs: all other keyword arguments are passed to K2SC.
     Returns
     -------
     time : array-like
@@ -1132,7 +1133,7 @@ def createlightcurve(targettpf, apply_K2SC=False, remove_spline=False, save_lc=F
                                         max_p=strip_quantity(lclist[variableindex].time).ptp()/2)
                 print('Proposed period for periodic kernel is %.2f' % period)
 
-                lclist[variableindex].k2sc(campaign=campaignnum, kernel='quasiperiodic',kernel_period=period)
+                lclist[variableindex].k2sc(campaign=campaignnum, kernel='quasiperiodic',kernel_period=period,**kwargs)
 
 
                 # --- Removing outliers before saving light curve (or removing spline) ---

--- a/src/autoeapcore.py
+++ b/src/autoeapcore.py
@@ -836,7 +836,7 @@ def optimize_aperture_wrt_CDPP(lclist,variableindex,gapfilledaperturelist,initia
             axs[0].set_ylabel('Flux')
             axs[0].set_title('The lc which is identified as a variable')
 
-            taxs[1].plot( strip_quantity(newlc.time) ,strip_quantity(newlc.flux) ,c='k')
+            axs[1].plot( strip_quantity(newlc.time) ,strip_quantity(newlc.flux) ,c='k')
             axs[1].set_xlabel('Time')
             axs[1].set_ylabel('Flux')
             axs[1].set_title('The lc after aperture size optimization')

--- a/src/autoeapcore.py
+++ b/src/autoeapcore.py
@@ -424,7 +424,7 @@ def aperture_prep(inputfile,campaign=None,show_plots=False,save_plots=False):
     mask_saturated  = np.zeros_like( strip_quantity(tpf.flux[0]) ,dtype=np.int)
     for i,tpfdata in tqdm(enumerate(tpf.flux[core_samples_mask]),total=len(tpf.flux[core_samples_mask])):
         # Mask saturated pixels
-        mask_saturated[tpfdata>190000] = 1
+        mask_saturated[strip_quantity(tpfdata)>190000] = 1
         # Do not mask middle region as it may contain a bright target
         mask_saturated[ 2:tpf.flux.shape[1]-2  , 2:tpf.flux.shape[2]-2  ] = 0
         tpfdata[   mask_saturated==1 ] = 0

--- a/src/autoeapcore.py
+++ b/src/autoeapcore.py
@@ -659,7 +659,7 @@ def which_one_is_a_variable(lclist,iterationnum,eachfile,show_plots=False,save_p
         power     = strip_quantity(power)
 
         sixhourspeak = 4.06998484731612
-        df = 1/lc.time.ptp()
+        df = 1/strip_quantity(lc.time).ptp()
         for jj in range(5):
             umcut = np.where( np.logical_and(frequency>(jj+1)*sixhourspeak-3*df,frequency<(jj+1)*sixhourspeak+3*df )  )
             power[umcut]     = np.nan

--- a/src/autoeapcore.py
+++ b/src/autoeapcore.py
@@ -335,17 +335,26 @@ def aperture_prep(inputfile,campaign=None,show_plots=False,save_plots=False):
         print('Local TPF not found, trying to download TPF instead')
         result = lightkurve.search_targetpixelfile(inputfile,campaign=campaign)
         if len(result)>1:
-            warnings.warn('The target has been observed in the following campaigns: '+\
-            str(result.table['observation'].tolist())+\
-            '. Only the first file has been downloaded. Please specify campaign (campaign=<number>) to limit your search.',
-            LightkurveWarning)
+            try:
+                warnings.warn('The target has been observed in the following campaigns: '+\
+                str(result.table['observation'].tolist())+\
+                '. Only the first file has been downloaded. Please specify campaign (campaign=<number>) to limit your search.',
+                LightkurveWarning)
+            except KeyError:
+                warnings.warn('The target has been observed in the following campaigns: '+\
+                str(result.table['mission'].tolist())+\
+                '. Only the first file has been downloaded. Please specify campaign (campaign=<number>) to limit your search.',
+                LightkurveWarning)
 
             tpf = result[0].download()
         else:
             if len(result) == 0:
                 raise FileNotFoundError('Empty search result. No target has been found in the given campaign!')
             tpf = result.download()
-            print('TPF found on MAST: '+result.table['observation'].tolist()[0] )
+            try:
+                print('TPF found on MAST: '+result.table['observation'].tolist()[0] )
+            except KeyError:
+                print('TPF found on MAST: '+result.table['mission'].tolist()[0] )
 
     # --- Add underscores to output filenames ---
     inputfile = inputfile.replace(' ','_')

--- a/src/k2sc_stable.py
+++ b/src/k2sc_stable.py
@@ -323,12 +323,18 @@ class k2sc_lc(lightkurve.KeplerLightCurve):
         return dataset
 
     def k2sc(self,**kwargs):
+        from astropy.units import UnitConversionError
+
         dataset = self.get_k2data()
         results = detrend(dataset,**kwargs) # see keyword arguments from detrend above
-        self.tr_position = results.tr_position
-        self.tr_time = results.tr_time
-        self.pv = results.pv # hyperparameters
         try:
-            self.corr_flux = self.flux.value - self.tr_position + np.nanmedian(self.tr_position)
-        except AttributeError:
-            self.corr_flux = self.flux - self.tr_position + np.nanmedian(self.tr_position)
+          self.tr_position = results.tr_position
+          self.tr_time = results.tr_time
+          self.pv = results.pv # hyperparameters
+          self.corr_flux = self.flux - self.tr_position + np.nanmedian(self.tr_position)
+        except UnitConversionError:
+          unit = self.flux.unit
+
+          self['tr_position'] = results.tr_position
+          self['tr_time'] = results.tr_time
+          self['corr_flux'] = self.flux - self.tr_position*unit + np.nanmedian(self.tr_position)*unit


### PR DESCRIPTION
As Lightkurve2.0 forces each value to be Quantity, we have to take care of it and separate the values from the units otherwise some functions won't work. In Lightkurve2.0, light curve objects are astropy tables, and e.g. adding new arrays to tables as attributes won't work.